### PR TITLE
Implements MeasureType CoverPath

### DIFF
--- a/SpotifyPlugin/SpotifyAPI.cs
+++ b/SpotifyPlugin/SpotifyAPI.cs
@@ -82,7 +82,7 @@ namespace SpotifyPlugin
             procs = Process.GetProcessesByName("Spotify");
             if (procs.Length < 1)
             {
-                Rm.Log(Rm.LogType.Warning, "Spotify is not running");
+                Rm.Log(Rm.LogType.Debug, "Spotify is not running");
                 //Out.Log(Verbosity.WARNING, "Spotify is not running");
                 return false;
             }

--- a/SpotifyPlugin/SpotifyPlugin.cs
+++ b/SpotifyPlugin/SpotifyPlugin.cs
@@ -234,6 +234,9 @@ namespace SpotifyPlugin
                 case MeasureType.AlbumName:
                     return toUTF8(Current_Status.track.album_resource.name);
 
+                case MeasureType.CoverPath:
+                    return StatusControl.CoverPath;
+
             }
 
             // MeasureType.Major, MeasureType.Minor, and MeasureType.Number are

--- a/SpotifyPlugin/StatusControl.cs
+++ b/SpotifyPlugin/StatusControl.cs
@@ -20,6 +20,8 @@ namespace SpotifyPlugin
 
         public static int timeout = 5000;
 
+        public static String CoverPath = "";
+
         public static Status Current_Status
         {
             get
@@ -86,6 +88,7 @@ namespace SpotifyPlugin
             }
             // Change back to cover image
             useCover = true;
+            CoverPath = url;
             Out.Log(Verbosity.DEBUG, "Artwork updated");
         }
 


### PR DESCRIPTION
CoverPath is an unused MeasureType in the master branch. In this branch
it is implemented to be be a string output of the web address of the
AlbumArt. It is updated on finish of the downloading of the album art.
The intent is for users to be able to be able to use OnChange events on
measures of this type and not have to worry about the update rate of the
album art measure being too slow and the OnChange not firing or having
to deal with it double firing.