### PR TITLE
seek and seekpercent bangs (fixes #12)

### DIFF
--- a/SpotifyPlugin/Parent.cs
+++ b/SpotifyPlugin/Parent.cs
@@ -199,7 +199,7 @@ namespace SpotifyPlugin
 
         public void Seek(int positionMs)
         {
-            ErrorResponse er = WebAPI.SeekPlayback(positionMs * 1000);
+            ErrorResponse er = WebAPI.SeekPlayback(positionMs);
             if (CorrectResponse(er)) return;
         }
 

--- a/SpotifyPlugin/Parent.cs
+++ b/SpotifyPlugin/Parent.cs
@@ -199,7 +199,7 @@ namespace SpotifyPlugin
 
         public void Seek(int positionMs)
         {
-            ErrorResponse er = WebAPI.SeekPlayback(0);
+            ErrorResponse er = WebAPI.SeekPlayback(positionMs * 1000);
             if (CorrectResponse(er)) return;
         }
 

--- a/SpotifyPlugin/SpotifyPlugin.cs
+++ b/SpotifyPlugin/SpotifyPlugin.cs
@@ -184,7 +184,7 @@ namespace SpotifyPlugin
                                 API.Log(API.LogType.Warning, $"Invalid arguments for command: {args[0]}. {args[1]} should be an integer.");
                                 return;
                             }
-                            parent.Seek(positionMs);
+                            parent.Seek(positionMs * 1000);
                             return;
                         case "seekpercent":
                         case "setposition":

--- a/SpotifyPlugin/SpotifyPlugin.cs
+++ b/SpotifyPlugin/SpotifyPlugin.cs
@@ -179,12 +179,12 @@ namespace SpotifyPlugin
                             parent.SetVolume(volume);
                             return;
                         case "seek":
-                            if (!Int32.TryParse(args[1], out int positionMs))
+                            if (!Int32.TryParse(args[1], out int positionS))
                             {
                                 API.Log(API.LogType.Warning, $"Invalid arguments for command: {args[0]}. {args[1]} should be an integer.");
                                 return;
                             }
-                            parent.Seek(positionMs * 1000);
+                            parent.Seek(positionS * 1000);
                             return;
                         case "seekpercent":
                         case "setposition":


### PR DESCRIPTION
This PR fixes the seek and seekpercent/setposition bangs, and should work without further changes (although I am unable to test without an API key. If testing is requested I can register my own API key for the plugin).